### PR TITLE
Github action PR announcemnt

### DIFF
--- a/.github/workflows/pr_announcement.yml
+++ b/.github/workflows/pr_announcement.yml
@@ -1,0 +1,46 @@
+name: pr_announcement
+
+on:
+
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  commnet-to-pr:
+    name: Do an announcement to PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        with:
+          app_id: ${{ secrets.MR_AVOCADO_ID }}
+          installation_id: ${{ secrets.MR_AVOCADO_INSTALLATION_ID }}
+          private_key: ${{ secrets.MR_AVOCADO_PRIVATE_KEY }}
+      - name: Get PR ID
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+		pr_data=$(gh api graphql -f query='query {
+			repository(owner:"richtja", name:"avocado") {
+				pullRequest(number:${{ github.event.number }}) {
+					id
+				}
+			}
+		}')
+		echo 'PR_ID='$(echo $pr_data | jq .data.repository.pullRequest.id) >> $GITHUB_ENV
+      - name: comment on PR
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+		gh api graphql -f query='mutation {
+			addComment(input: {
+				subjectId: ${{ env.PR_ID }},
+				body: "This is a kindly reminder of ongoing release voting. Please use :+1:  or :-1:  for this discussion to vote.
+				Thank you.\n\nNew commits from the beginning of the voting:\nThis vote is meat only for maintainers:"}) {
+
+					clientMutationId
+			}
+              }
+              '


### PR DESCRIPTION
This is a new workflow which will add announcement about LTS release to every new PR. It is a good way how to inform community about merge rules during the LTS version preparations.